### PR TITLE
Add Localization

### DIFF
--- a/src/main/resources/assets/uiesingularities/lang/en_US.lang
+++ b/src/main/resources/assets/uiesingularities/lang/en_US.lang
@@ -11,6 +11,7 @@ item.universalSingularities.vanilla.emerald.name=Emerald Singularity
 //Vanilla
 
 //General
+item.avaritia_singularity.name=Singularity
 item.universalSingularities.general.aluminum.name=Aluminum Singularity
 item.universalSingularities.general.brass.name=Brass Singularity
 item.universalSingularities.general.bronze.name=Bronze Singularity


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.