### PR TITLE
Add Circuit Computation Singularities

### DIFF
--- a/src/main/java/wealthyturtle/uiesingularities/proxy/CommonProxy.java
+++ b/src/main/java/wealthyturtle/uiesingularities/proxy/CommonProxy.java
@@ -660,6 +660,7 @@ public class CommonProxy {
                                         0x6B6866,
                                         0x6B6866,
                                         true))),
+                // Toxic Singularity
                 new UniversalSingularity(
                         "toxic",
                         Arrays.asList(
@@ -669,7 +670,37 @@ public class CommonProxy {
                                         633,
                                         0x687351,
                                         0x506b4c,
-                                        true))));
+                                        true))),
+                // Gregtech Circuit Singularities
+                new UniversalSingularity(
+                        "circuit",
+                        Arrays.asList(
+                                new UniversalSingularityWrapper("ulv", "blockArdite", 102, 0xFFFFFF, 0xE7E7E7, true),
+                                new UniversalSingularityWrapper("lv", "blockArdite", 506, 0xAAAAAA, 0x969696, true),
+                                new UniversalSingularityWrapper("mv", "blockArdite", 182, 0xFFAA00, 0xD18B00, true),
+                                new UniversalSingularityWrapper("hv", "blockArdite", 125, 0xFFFF55, 0xFFFF2E, true),
+                                new UniversalSingularityWrapper("ev", "blockArdite", 124, 0x555555, 0x3B3B3B, true),
+                                new UniversalSingularityWrapper("iv", "blockArdite", 120, 0x55FF55, 0x2EFF2E, true),
+                                new UniversalSingularityWrapper("luv", "blockArdite", 592, 0xFF55FF, 0xFF2EFF, true),
+                                new UniversalSingularityWrapper("zpm", "blockArdite", 621, 0x55FFFF, 0x2EFFFF, true),
+                                new UniversalSingularityWrapper("uv", "blockArdite", 323, 0x00AA00, 0x007500, true),
+                                new UniversalSingularityWrapper("uhv", "blockArdite", 641, 0xAA0000, 0x750000, true))),
+                // meta 10 and 11 have custom effects, split to avoid these
+                new UniversalSingularity(
+                        "circuit2",
+                        Arrays.asList(
+                                new UniversalSingularityWrapper("uev", "blockArdite", 412, 0xAA00AA, 0x750075, true),
+                                new UniversalSingularityWrapper("uiv", "blockArdite", 254, 0x0000AA, 0x000075, true),
+                                new UniversalSingularityWrapper("umv", "blockArdite", 296, 0xFF5555, 0xFF2E2E, true),
+                                new UniversalSingularityWrapper("uxv", "blockArdite", 583, 0xD100D1, 0xD10000, true),
+                                new UniversalSingularityWrapper("max", "blockArdite", 698, 0xFFFFFF, 0xFFFF55, true),
+                                new UniversalSingularityWrapper(
+                                        "erv",
+                                        "blockArdite",
+                                        813,
+                                        0x181818,
+                                        0x555555,
+                                        false))));
 
         /*
          * Removed new UniversalSingularityWrapper("salt", "blockSalt", 87, 0xEFEFEF, 0xDDE7E8), new

--- a/src/main/resources/assets/uiesingularities/lang/en_US.lang
+++ b/src/main/resources/assets/uiesingularities/lang/en_US.lang
@@ -59,6 +59,24 @@ item.universalSingularities.rubber.elastic.name=Elastic Singularity
 //Toxic
 item.universalSingularities.toxic.contaminated.name=Contaminated Singularity
 
+//Circuit
+item.universalSingularities.circuit.ulv.name=Ultra Low Computation Singularity
+item.universalSingularities.circuit.lv.name=Low Computation Singularity
+item.universalSingularities.circuit.mv.name=Medium Computation Singularity
+item.universalSingularities.circuit.hv.name=High Computation Singularity
+item.universalSingularities.circuit.ev.name=Extreme Computation Singularity
+item.universalSingularities.circuit.iv.name=Insane Computation Singularity
+item.universalSingularities.circuit.luv.name=Ludicrous Computation Singularity
+item.universalSingularities.circuit.zpm.name=ZPM Computation Singularity
+item.universalSingularities.circuit.uv.name=Ultimate Computation Singularity
+item.universalSingularities.circuit2.uhv.name=Highly Ultimate Computation Singularity
+item.universalSingularities.circuit2.uev.name=Extremely Ultimate Computation Singularity
+item.universalSingularities.circuit2.uiv.name=Insanely Ultimate Computation Singularity
+item.universalSingularities.circuit2.umv.name=Mega Ultimate Computation Singularity
+item.universalSingularities.circuit2.uxv.name=Extended Mega Ultimate Computation Singularity
+item.universalSingularities.circuit2.max.name=Maximum Computation Singularity
+item.universalSingularities.circuit2.erv.name=Error Computation Singularity
+
 //Big Reactors
 item.universalSingularities.bigReactors.blutonium.name=Blutonium Singularity
 item.universalSingularities.bigReactors.cyanite.name=Cyanite Singularity


### PR DESCRIPTION
Adds computation singularity items, no recipes in this pr.
A singularity per gt circuit tier, designed to push cals and nac to its limits. These singularities will take mainframes (when able), making all circuit lines needed for gate.

These singularities will be combined in the dire table to make the Robotic Singularity (will be renamed), and then used in the 2.9 Stargate Core Crystal (the one used in the dial)

<img width="495" height="118" alt="image" src="https://github.com/user-attachments/assets/45b562f7-1663-4ed8-9e9e-1298235f7624" />

ULV-ERV

(error singularity is disabled, but will be used after temporal mainframes get added (error being the final final final final gate circuits))